### PR TITLE
Added GitHub Action for SEPIA CI

### DIFF
--- a/.github/workflows/SEPIA-CI.yml
+++ b/.github/workflows/SEPIA-CI.yml
@@ -1,0 +1,30 @@
+name: SEPIA-CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]
+        # NOTE: Example for excluding specific python versions for an different OS's.
+        # exclude:
+        #   - os: windows-latest
+        #     python-version: 3.6
+        #   - os: macos-latest
+        #     python-version: 3.8
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Test with unittest
+      run: |
+        python -m unittest discover -s test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SEPIA
+[![SEPIA-CI Status][ci-status-img]](https://github.com/lanl/SEPIA/actions)
 
 Simulation-Enabled Prediction, Inference, and Analysis: physics-informed statistical learning.
 This is a Python adaptation of [GPMSA](https://github.com/lanl/gpmsa).
@@ -89,3 +90,4 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+[ci-status-img]: https://github.com/lanl/SEPIA/workflows/SEPIA-CI/badge.svg


### PR DESCRIPTION
Hi,

This PR adds a GitHub Action to run tests for SEPIA.

The only file added is `.github/workflows/SEPIA-CI.yml`. Two lines were added in `README.md`, to show the status of the tests (pass / fail).

With this PR merged, whenever someone submits a PR (in the future), tests will be run (on some GitHub server), on the latest windows, macos, and ubuntu versions for python 3.6, 3.7, 3.8. Other python versions can be added as demonstrated in `SEPIA-CI.yml`. You (and everyone on GitHub) will then be able to see, on GitHub, if tests pass before deciding to merge the PR.

Arthur